### PR TITLE
Avoid conflict with requirejs-export-plugin v1.1.0

### DIFF
--- a/RequireJsLoaderPlugin.js
+++ b/RequireJsLoaderPlugin.js
@@ -30,6 +30,11 @@ function generateEpilog(imports) {
 RequireJsLoaderPlugin.prototype.apply = function(compiler) {
     compiler.plugin('compilation', (compilation, data) => {
         compilation.plugin('chunk-asset', (chunk, filename) => {
+            // Avoid applying imports twice.
+            if ('--requirejs-export:done' in chunk) {
+                return;
+            }
+
             const needsImport = gatherRequireJsImports(chunk.modules);
             if (needsImport.length != 0) {
                 let prolog = generateProlog(needsImport);


### PR DESCRIPTION
Just to ensure we don't wrap the imports twice if someone uses this plugin too.