### PR TITLE
Hotfix/jquery mixins

### DIFF
--- a/RequireJsLoaderPlugin.js
+++ b/RequireJsLoaderPlugin.js
@@ -10,7 +10,9 @@ function gatherRequireJsImports(modules) {
     for (var module of modules) {
         // If the requirejs-loader was used, then we need to wrap and import this module.
         // TODO: Clean up this check.
-        if (module.request && module.request.indexOf('requirejs-loader') !== -1) {
+        if (module.request && String(module.request).indexOf('jquery.js') !== -1) {
+            needsImport.push('mixins!' + module.rawRequest);
+        } else if (module.request && module.request.indexOf('requirejs-loader') !== -1) {
             needsImport.push(module.rawRequest);
         }
     }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports.pitch = function(remainingRequest) {
 
     // Route through window.require.
     // TODO: We use rawRequest to grab the original request (including text! or etc.)
-    const jsonName = JSON.stringify(this._module.rawRequest);
+    const prefix = (this._module.rawRequest == 'jquery') ? 'mixins!' : '';
+    const jsonName = JSON.stringify(prefix + this._module.rawRequest);
     return `module.exports = window.require(${jsonName});`;
 };
 


### PR DESCRIPTION
Magento added a jQuery patch in all recent releases 2.1.16, 2.2.7, 2.3.0 which broke jQuery for us. This references the mixins versions: magento/magento2@d588b5b