### PR TITLE
Support newer webpack versions and use mixins always

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Allows the import of requirejs packages through the browser.
 
 This is specifically useful for Magento 2, which extensively uses requirejs.
 
+Currently, a prefix of `mixins!` is added, so this is only usable with Magento 2.
+
 ## Usage
+
+In webpack.config.js:
 
     const RequireJsLoaderPlugin = require('@sdinteractive/requirejs-loader').RequireJsLoaderPlugin;
 
@@ -24,3 +28,7 @@ This is specifically useful for Magento 2, which extensively uses requirejs.
         new RequireJsLoaderPlugin(),
       ],
     };
+
+In Magento 2, you'll normally want to include the pub/static/Vendor/theme/locale folder in the module resolve paths.
+Adjust the test/exclude rules so that the loader only applies when loading requirejs files, so you can still import
+things from node_modules and similar via webpack.

--- a/RequireJsLoaderPlugin.js
+++ b/RequireJsLoaderPlugin.js
@@ -2,12 +2,12 @@
 
 const ConcatSource = require('webpack-sources').ConcatSource;
 
-let RequireJsLoaderPlugin = function() {
+let RequireJsLoaderPlugin = function () {
 };
 
 function gatherRequireJsImports(modules) {
     let needsImport = [];
-    for (var module of modules) {
+    for (let module of modules) {
         // If the requirejs-loader was used, then we need to wrap and import this module.
         // TODO: Clean up this check.
         if (module.request && String(module.request).indexOf('jquery.js') !== -1) {
@@ -22,14 +22,14 @@ function gatherRequireJsImports(modules) {
 
 function generateProlog(imports) {
     const jsonImports = JSON.stringify(imports);
-    return `window.require(${jsonImports}, function() {`;
+    return `window.require(${jsonImports}, function () {`;
 }
 
 function generateEpilog(imports) {
     return `});`;
 }
 
-RequireJsLoaderPlugin.prototype.apply = function(compiler) {
+RequireJsLoaderPlugin.prototype.apply = function (compiler) {
     compiler.plugin('compilation', (compilation, data) => {
         compilation.plugin('chunk-asset', (chunk, filename) => {
             // Avoid applying imports twice.

--- a/RequireJsLoaderPlugin.js
+++ b/RequireJsLoaderPlugin.js
@@ -9,11 +9,10 @@ function gatherRequireJsImports(modules) {
     let needsImport = [];
     for (let module of modules) {
         // If the requirejs-loader was used, then we need to wrap and import this module.
+        // It's safe to use mixins! in all cases, and necessary for anything where require('mixins').hasMixins(module) is true.
         // TODO: Clean up this check.
-        if (module.request && String(module.request).indexOf('jquery.js') !== -1) {
+        if (module.request && module.request.indexOf('requirejs-loader') !== -1) {
             needsImport.push('mixins!' + module.rawRequest);
-        } else if (module.request && module.request.indexOf('requirejs-loader') !== -1) {
-            needsImport.push(module.rawRequest);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@
 const path = require('path');
 const ConcatSource = require('webpack-sources').ConcatSource;
 
-module.exports = function() {
+module.exports = function () {
 };
 
-module.exports.pitch = function(remainingRequest) {
+module.exports.pitch = function (remainingRequest) {
 	this.cacheable && this.cacheable();
 
     // Route through window.require.

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ module.exports.pitch = function (remainingRequest) {
 	this.cacheable && this.cacheable();
 
     // Route through window.require.
+    // It's safe to use mixins! in all cases, and necessary for anything where require('mixins').hasMixins(module) is true.
     // TODO: We use rawRequest to grab the original request (including text! or etc.)
-    const prefix = (this._module.rawRequest == 'jquery') ? 'mixins!' : '';
-    const jsonName = JSON.stringify(prefix + this._module.rawRequest);
+    const jsonName = JSON.stringify('mixins!' + this._module.rawRequest);
     return `module.exports = window.require(${jsonName});`;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sdinteractive/requirejs-loader",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "webpack loader to import requirejs browser published modules.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using the mixins requirejs loader means that we're now fairly tied to Magento 2, but it increases Magento 2 compatibility.